### PR TITLE
Allow bookmarklet.js to specify port 

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ To enable cross domain communictaion between your site and other pages on the 'n
 
     config.action_controller.default_url_options = {:host => 'localhost', :port => 3000}
 
+The port can also be supplied as a parameter in the bookmarklet.js file - this will override the value from the rails application. This is useful if you have middleware changing the port that the browser sees (e.g. nginx to implement ssl)
+
 XDM bookmarklet code acts as a consumer for data or a service that is
 supplied by the provider, a page on your app.  
 

--- a/app/assets/javascripts/easymarklet/consumer.js.erb
+++ b/app/assets/javascripts/easymarklet/consumer.js.erb
@@ -23,6 +23,10 @@
     }
     var host = '<%= Rails.application.config.action_controller.default_url_options[:host] %>';
     var port = '<%= Rails.application.config.action_controller.default_url_options[:port] %>';
+    // Allow port to be overriden by the bookmarklet definition - useful for ssl
+    if(bookmarklet.port) {
+      port = bookmarklet.port;
+    }
     port = port === '' ? '' : ':' + port;
     var full_host = protocol  + '://' + host + port;
 


### PR DESCRIPTION
Hi,

thanks for the gem!  I've made a small change to allow the user to specify a port, similar to the protocol override already implemented.

I've been using ssl, implemented by nginx middleware, but this approach means that the browser is using a different port from the server. The change allows me to override the port seen in rails, so I can supply the port used by the browser to consumer.js. 

I've added 3 lines of code to consumer.js and added a note to the README.md file. The note may be better moved to the wiki.

My code is on config-port branch to make it easier for you to compare before merging. This is my first open-source pull request!

Chris
